### PR TITLE
Make dev command download specific proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ CLI utility for downloading vscode.d.ts and vscode.proposed.d.ts
 
 ```bash
  ~ > npx vscode-dts
-vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.d.ts
+vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.<proposal>.d.ts
 
 Usage:
-  - npx vscode-dts dev                          Download vscode.proposed.d.ts
-  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposed.d.ts from git tag/branch of microsoft/vscode
-  - npx vscode-dts <git-tag | git-branch>       Download vscode.d.ts from git tag/branch of microsoft/vscode
-  - npx vscode-dts <git-tag | git-branch> -f    Download vscode.d.ts and remove conflicting types in node_modules/@types/vscode
-  - npx vscode-dts                              Print Help
-  - npx vscode-dts -h                           Print Help
-  - npx vscode-dts --help                       Print Help
+  - npx vscode-dts dev <proposal>                            Download vscode.proposed.<proposal>.d.ts files
+  - npx vscode-dts dev <proposal> -g <git-tag | git-branch>  Download vscode.proposed.<proposal>.d.ts files from git tag/branch of microsoft/vscode
+  - npx vscode-dts <git-tag | git-branch>                    Download vscode.d.ts from git tag/branch of microsoft/vscode
+  - npx vscode-dts <git-tag | git-branch> -f                 Download vscode.d.ts and remove conflicting types in node_modules/@types/vscode
+  - npx vscode-dts                                           Print Help
+  - npx vscode-dts -h                                        Print Help
+  - npx vscode-dts --help                                    Print Help
 ```
 
 ## License


### PR DESCRIPTION
Changes the `dev` command to fetch individual `vscode.proposed.XYZ.d.ts`-files. 

This introduces a small asymmetry because the git-tag/branch is given via the `-g`-flag, but only for dev-command. Open for suggestions!

```
vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.<proposal>.d.ts

Usage:
  - npx vscode-dts dev <proposal>                            Download vscode.proposed.<proposal>.d.ts files
  - npx vscode-dts dev <proposal> -g <git-tag | git-branch>  Download vscode.proposed.<proposal>.d.ts files from git tag/branch of microsoft/vscode
  - npx vscode-dts <git-tag | git-branch>                    Download vscode.d.ts from git tag/branch of microsoft/vscode
  - npx vscode-dts <git-tag | git-branch> -f                 Download vscode.d.ts and remove conflicting types in node_modules/@types/vscode
  - npx vscode-dts                                           Print Help
  - npx vscode-dts -h                                        Print Help
  - npx vscode-dts --help                                    Print Help
```