### PR TITLE
Make dev command fetch proposals as defined in `enabledApiProposals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ CLI utility for downloading vscode.d.ts and vscode.proposed.d.ts
 
 ```bash
  ~ > npx vscode-dts
-vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.d.ts
+vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.<proposal>.d.ts
 
 Usage:
-  - npx vscode-dts dev                          Download vscode.proposed.d.ts
-  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposed.d.ts from git tag/branch of microsoft/vscode
+  - npx vscode-dts dev                          Download vscode.proposaled.<proposal>.d.ts files
+  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposaled.<proposal>.d.ts files from git tag/branch of microsoft/vscode
   - npx vscode-dts <git-tag | git-branch>       Download vscode.d.ts from git tag/branch of microsoft/vscode
   - npx vscode-dts <git-tag | git-branch> -f    Download vscode.d.ts and remove conflicting types in node_modules/@types/vscode
   - npx vscode-dts                              Print Help

--- a/index.js
+++ b/index.js
@@ -23,25 +23,28 @@ else if (argv._[0]) {
 }
 function handleDev(gitTagOrBranch) {
     if (gitTagOrBranch === void 0) { gitTagOrBranch = 'main'; }
-    var url = "https://raw.githubusercontent.com/microsoft/vscode/" + gitTagOrBranch + "/src/vscode-dts/vscode.proposed.d.ts";
-    var legacyUrl = "https://raw.githubusercontent.com/microsoft/vscode/" + gitTagOrBranch + "/src/vs/vscode.proposed.d.ts";
-    var outPath = path_1["default"].resolve(process.cwd(), './vscode.proposed.d.ts');
-    console.log("Downloading vscode.proposed.d.ts\nTo:   " + outPath + "\nFrom: " + url);
-    download(url, outPath)["catch"](function () { return download(legacyUrl, outPath); }).then(function () {
-        if (!isProposedApiEnabled()) {
-            console.log("Please set " + toRedString("\"enableProposedApi\": true") + " in package.json.");
-        }
-        console.log('Read more about proposed API at: https://code.visualstudio.com/api/advanced-topics/using-proposed-api');
-    });
+    var proposalNames = getEnabledApiProposals();
+    if (proposalNames.length === 0) {
+        console.error("No proposals in the \"enabledApiProposals\"-property of package.json found.");
+        return;
+    }
+    for (var _i = 0, proposalNames_1 = proposalNames; _i < proposalNames_1.length; _i++) {
+        var name_1 = proposalNames_1[_i];
+        var url = "https://raw.githubusercontent.com/microsoft/vscode/" + gitTagOrBranch + "/src/vscode-dts/vscode.proposed." + name_1 + ".d.ts";
+        var outPath = path_1["default"].resolve(process.cwd(), "./vscode.proposed." + name_1 + ".d.ts");
+        console.log("Downloading vscode.proposed." + toGreenString(name_1) + ".d.ts\nTo:   " + outPath + "\nFrom: " + url);
+        download(url, outPath)["catch"](function (err) { return console.error(err); });
+    }
+    console.log('Read more about proposed API at: https://code.visualstudio.com/api/advanced-topics/using-proposed-api');
 }
-function isProposedApiEnabled() {
+function getEnabledApiProposals() {
     try {
         var packageJsonPath = path_1["default"].resolve(process.cwd(), './package.json');
         var packageJson = JSON.parse(fs_1["default"].readFileSync(packageJsonPath, 'utf-8'));
-        return !!packageJson.enableProposedApi;
+        return Array.isArray(packageJson.enabledApiProposals) ? packageJson.enabledApiProposals : [];
     }
     catch (_a) {
-        return false;
+        return [];
     }
 }
 function handleDefaultDownload(gitTagOrBranch, force) {
@@ -143,4 +146,7 @@ function removeNodeModulesTypes() {
 }
 function toRedString(s) {
     return "\u001B[31m" + s + "\u001B[0m";
+}
+function toGreenString(s) {
+    return "\u001B[32m" + s + "\u001B[0m";
 }

--- a/index.js
+++ b/index.js
@@ -67,11 +67,11 @@ function handleDefaultDownload(gitTagOrBranch, force) {
 }
 function getHelpMessage() {
     return [
-        'vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.d.ts',
+        'vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.<proposal>.d.ts',
         '',
         'Usage:',
-        '  - npx vscode-dts dev                          Download vscode.proposed.d.ts',
-        '  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposed.d.ts from git tag/branch of microsoft/vscode',
+        '  - npx vscode-dts dev                          Download vscode.proposaled.<proposal>.d.ts files',
+        '  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposaled.<proposal>.d.ts files from git tag/branch of microsoft/vscode',
         '  - npx vscode-dts <git-tag | git-branch>       Download vscode.d.ts from git tag/branch of microsoft/vscode',
         '  - npx vscode-dts <git-tag | git-branch> -f    Download vscode.d.ts and remove conflicting types in node_modules/@types/vscode',
         '  - npx vscode-dts                              Print Help',

--- a/index.ts
+++ b/index.ts
@@ -69,11 +69,11 @@ function handleDefaultDownload(gitTagOrBranch: string, force?: boolean) {
 
 function getHelpMessage() {
   return [
-    'vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.d.ts',
+    'vscode-dts: CLI utility for downloading vscode.d.ts and vscode.proposed.<proposal>.d.ts',
     '',
     'Usage:',
-    '  - npx vscode-dts dev                          Download vscode.proposed.d.ts',
-    '  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposed.d.ts from git tag/branch of microsoft/vscode',
+    '  - npx vscode-dts dev                          Download vscode.proposaled.<proposal>.d.ts files',
+    '  - npx vscode-dts dev <git-tag | git-branch>   Download vscode.proposaled.<proposal>.d.ts files from git tag/branch of microsoft/vscode',
     '  - npx vscode-dts <git-tag | git-branch>       Download vscode.d.ts from git tag/branch of microsoft/vscode',
     '  - npx vscode-dts <git-tag | git-branch> -f    Download vscode.d.ts and remove conflicting types in node_modules/@types/vscode',
     '  - npx vscode-dts                              Print Help',

--- a/index.ts
+++ b/index.ts
@@ -20,26 +20,30 @@ if (argv._.length === 0 || argv['h'] || argv['help']) {
 
 function handleDev(gitTagOrBranch: string = 'main') {
 
-  const url = `https://raw.githubusercontent.com/microsoft/vscode/${gitTagOrBranch}/src/vscode-dts/vscode.proposed.d.ts`
-  const legacyUrl = `https://raw.githubusercontent.com/microsoft/vscode/${gitTagOrBranch}/src/vs/vscode.proposed.d.ts`
-  const outPath = path.resolve(process.cwd(), './vscode.proposed.d.ts')
-  console.log(`Downloading vscode.proposed.d.ts\nTo:   ${outPath}\nFrom: ${url}`)
+  const proposalNames = getEnabledApiProposals();
+  if (proposalNames.length === 0) {
+    console.error(`No proposals in the "enabledApiProposals"-property of package.json found.`)
+    return;
+  }
 
-  download(url, outPath).catch(() => download(legacyUrl, outPath)).then(() => {
-    if (!isProposedApiEnabled()) {
-      console.log(`Please set ${toRedString(`"enableProposedApi": true`)} in package.json.`)
-    }
-    console.log('Read more about proposed API at: https://code.visualstudio.com/api/advanced-topics/using-proposed-api')
-  })
+  for (const name of proposalNames) {
+    const url = `https://raw.githubusercontent.com/microsoft/vscode/${gitTagOrBranch}/src/vscode-dts/vscode.proposed.${name}.d.ts`
+    const outPath = path.resolve(process.cwd(), `./vscode.proposed.${name}.d.ts`)
+    console.log(`Downloading vscode.proposed.${toGreenString(name)}.d.ts\nTo:   ${outPath}\nFrom: ${url}`)
+
+    download(url, outPath).catch(err => console.error(err))
+  }
+
+  console.log('Read more about proposed API at: https://code.visualstudio.com/api/advanced-topics/using-proposed-api')
 }
 
-function isProposedApiEnabled() {
+function getEnabledApiProposals(): string[] {
   try {
     const packageJsonPath = path.resolve(process.cwd(), './package.json')
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-    return !!packageJson.enableProposedApi
+    return Array.isArray(packageJson.enabledApiProposals) ? packageJson.enabledApiProposals : []
   } catch {
-    return false
+    return []
   }
 }
 
@@ -146,4 +150,8 @@ function removeNodeModulesTypes() {
 
 function toRedString(s: string) {
   return `\x1b[31m${s}\x1b[0m`
+}
+
+function toGreenString(s: string) {
+  return `\x1b[32m${s}\x1b[0m`
 }


### PR DESCRIPTION
Changes the dev command to fetch individual vscode.proposed.XYZ.d.ts-files. What files to fetch is defined by `package.json#enabledApiProposals` as suggested here https://github.com/microsoft/vscode-dts/pull/10#issuecomment-966506896